### PR TITLE
Fix IndexOutOfBounds thrown with unstacked exploding-creeper-kills-stack

### DIFF
--- a/src/com/kiwifisher/mobstacker/utils/StackUtils.java
+++ b/src/com/kiwifisher/mobstacker/utils/StackUtils.java
@@ -1,14 +1,13 @@
 package com.kiwifisher.mobstacker.utils;
 
 import com.kiwifisher.mobstacker.MobStacker;
-import com.kiwifisher.mobstacker.listeners.MobSpawnListener;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.material.Colorable;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.metadata.MetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 import java.util.List;
 
@@ -398,14 +397,11 @@ public class StackUtils {
      * @return Returns number of mobs.
      */
     public static int getStackSize(LivingEntity livingEntity) {
-        try {
-            return livingEntity.getMetadata("quantity").get(0).asInt();
-        } catch (NullPointerException e) {
-            e.printStackTrace();
+        List<MetadataValue> list = livingEntity.getMetadata("quantity");
+        if (list.isEmpty()) {
+            return 0;
         }
-
-        return 0;
-
+        return list.get(0).asInt();
     }
 
     /*


### PR DESCRIPTION
Entity#getMetadata [never returns null](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/metadata/MetadataStoreBase.java#56), it will return an empty List if no metadata exists.
In addition, checking if the exploding entity is actually a stack at all before tacking on an additional explosion is probably a good idea.

One thing I didn't throw in the commit message that my mind was screaming: Why would you ever catch a NPE? Don't get me wrong, I've done it in the past, but you wouldn't catch me dead doing it now unless it's an internal Craftbukkit issue I have no control over.
Null checks are super easy to perform, and they have a lot lower footprint than the resources required when an exception is thrown.

~~Sorry about the import changes, I didn't remember to disable my import organization and variable finalization on save. I can go back and fix that if you want.~~
Fixed that when I realized we can just return fast when the entity exploding is not a LivingEntity or a stack. The original commit, e3db258f9289f684532575878dfe8108d7166d42, was much cleaner if you're after a nice read. I'm afraid Github went a little bonkers with trying to create a minimal diff for the decrease in indentation. 
