### PR TITLE
Load existing stacks when chunks load

### DIFF
--- a/src/com/kiwifisher/mobstacker/listeners/MobSpawnListener.java
+++ b/src/com/kiwifisher/mobstacker/listeners/MobSpawnListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,8 +31,16 @@ public class MobSpawnListener implements Listener {
     @EventHandler
     public void mobLoadEvent(ChunkLoadEvent event) {
 
-        // Check if stacking is enabled in this world.
-        if (!isStackable(event.getWorld())) {
+        // Check if loading stacks and stacking is enabled in this world.
+        if (!getPlugin().getConfig().getBoolean("load-existing-stacks.enabled") || !isStackable(event.getWorld())) {
+            return;
+        }
+
+        // Get acceptable mob types
+        List<String> types = getPlugin().getConfig().getStringList("load-existing-stacks.mob-types");
+
+        // Check if any mob types are acceptable
+        if (types.isEmpty()) {
             return;
         }
 
@@ -63,8 +72,8 @@ public class MobSpawnListener implements Listener {
 
         for (Entity entity : event.getChunk().getEntities()) {
 
-            // Check for a custom name. If not found, not an existing stack.
-            if (entity.getCustomName() == null) {
+            // Check for a custom name and an approved type. If not, not an existing stack.
+            if (entity.getCustomName() == null || !types.contains(entity.getType().name())) {
                 continue;
             }
 
@@ -164,8 +173,8 @@ public class MobSpawnListener implements Listener {
      * 
      * @param entity the Entity
      * @param reason the SpawnReason, or null if the chunk is being loaded.
-     * @param worldChecked
-     * @return
+     * @param worldChecked true if the world has already been checked
+     * @return true if the entity can be stacked
      */
     private boolean isStackable(Entity entity, SpawnReason reason, boolean worldChecked) {
 

--- a/src/com/kiwifisher/mobstacker/listeners/MobSpawnListener.java
+++ b/src/com/kiwifisher/mobstacker/listeners/MobSpawnListener.java
@@ -1,24 +1,105 @@
 package com.kiwifisher.mobstacker.listeners;
 
 import com.kiwifisher.mobstacker.MobStacker;
+
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 
-import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MobSpawnListener implements Listener {
 
-
-    private MobStacker plugin;
+    private final MobStacker plugin;
 
     public MobSpawnListener(MobStacker plugin) {
         this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void mobLoadEvent(ChunkLoadEvent event) {
+
+        // Check if stacking is enabled in this world.
+        if (!isStackable(event.getWorld())) {
+            return;
+        }
+
+        /*
+         * Assemble a regular expression for name matching.
+         * 
+         * Note that the pattern is very fiddly. I'd prefer to use named captures as there's no
+         * guarantee of order. However, since we don't actually need to check the entity type -
+         * that's optional security - I've opted to not capture the name group at all, meaning all
+         * capture groups are the quantity group and should be identical. You also can't have
+         * multiple named captures with the same name, which would occur if someone configured the
+         * quantity to appear twice, etc. If we do want to check entity type, it's possible (though
+         * somewhat a nuisance) to set up named captures by using a replaceFirst with the named
+         * capture, then a replace with the same pattern, just not named or potentially even
+         * non-capturing.
+         */
+        String type = getPlugin().getConfig().getString("stack-naming");
+
+        if (!type.contains("{QTY}")) {
+            // Quantity is not stored, we can't figure out how many there are.
+            return;
+        }
+
+        type = ChatColor.translateAlternateColorCodes('&', type);
+        StringBuilder builder = new StringBuilder("\\Q")
+                .append(type.replace("{QTY}", "\\E([0-9]+)\\Q").replace("{TYPE}", "\\E[A-Z ]+\\Q"))
+                .append("\\E");
+        Pattern pattern = Pattern.compile(builder.toString());
+
+        for (Entity entity : event.getChunk().getEntities()) {
+
+            // Check for a custom name. If not found, not an existing stack.
+            if (entity.getCustomName() == null) {
+                continue;
+            }
+
+            // Check if the entity can stack.
+            if (!isStackable(entity, null, true)) {
+                continue;
+            }
+
+            // Ensure we have a match with the name pattern.
+            Matcher matcher = pattern.matcher(entity.getCustomName());
+            if (!matcher.find()) {
+                continue;
+            }
+
+            // Cast to LivingEntity. This is safe, checked in isStackable.
+            LivingEntity living = (LivingEntity) entity;
+
+            // Parse stack size from matched group (see long comment above for group selection reasoning).
+            int stackSize;
+            try {
+                stackSize = Integer.valueOf(matcher.group(1));
+            } catch (NumberFormatException e) {
+                // There should be no way to hit this block given the regex, but it's better safe than sorry.
+                continue;
+            }
+
+            // Get max stack size for type.
+            int maxStackSize = getPlugin().getConfig().getInt(("max-stack-sizes.") + entity.getType().toString(), 0);
+
+            // Set metadata.
+            getPlugin().getStackUtils().setStackSize(living, stackSize);
+            getPlugin().getStackUtils().setMaxStack(living, maxStackSize > 0 && maxStackSize <= stackSize);
+
+        }
+
     }
 
     @EventHandler
@@ -27,78 +108,105 @@ public class MobSpawnListener implements Listener {
         final LivingEntity spawnedCreature = event.getEntity();
         final CreatureSpawnEvent.SpawnReason spawnReason = event.getSpawnReason();
 
-        /*
-        Make sure it isn't a bloody armour stand. Why the hell are these LivingEntities?
-         */
-        boolean entityIsArmorStand = false;
-
-        /*
-        If version used it 1.7 then there are no armour stands, so leave it false.
-        If version use is 1.8, check if it's an armour stand.
-         */
-        if (Bukkit.getVersion().contains("1.7")) {
-            entityIsArmorStand = false;
-        } else if (spawnedCreature.getType() == EntityType.ARMOR_STAND) {
-            entityIsArmorStand = true;
+        // Check if the spawned entity is stackable.
+        if (!isStackable(spawnedCreature, spawnReason, false)) {
+            return;
         }
 
         /*
-        If we're using world guard, check if the mob is in a region. If mob isn't allowed ot stack there, stop here. Don't check armour stands.
+        Set stack size to 1 and max stack to false;
          */
-        if (getPlugin().usesWorldGuard() && !entityIsArmorStand) {
+        getPlugin().getStackUtils().setStackSize(spawnedCreature, 1);
+        getPlugin().getStackUtils().setMaxStack(spawnedCreature, false);
 
-            RegionManager regionManager = getPlugin().getWorldGuard().getRegionManager(event.getEntity().getWorld());
+        /*
+        Check if the mob is from a spawner, and add the tag so that when it dies we can have continuity for
+        nerf-spawner-mobs
+         */
+        if (!spawnedCreature.hasMetadata("spawn-reason")) {
 
-            for (ProtectedRegion region : regionManager.getApplicableRegions(event.getEntity().getLocation()).getRegions()) {
+            spawnedCreature.setMetadata("spawn-reason", new FixedMetadataValue(getPlugin(), spawnReason));
 
+        }
+
+        /*
+        Make sure search time is positive and try to stack.
+         */
+        if (getPlugin().getSearchTime() >= -20) {
+            getPlugin().getStackUtils().attemptToStack(getPlugin().getSearchTime(), spawnedCreature, spawnReason);
+        }
+
+    }
+
+    /**
+     * Check if MobStacker is disabled in a world.
+     * 
+     * @param world the world to check
+     * @return true if MobStacker is stacking in the World
+     */
+    private boolean isStackable(World world) {
+
+        // Check if stacking is enabled.
+        if (!getPlugin().isStacking()) {
+            return false;
+        }
+
+        // Check if the world is in the blacklist.
+        if (getPlugin().getConfig().getStringList("blacklist-world").contains(world.getName().toLowerCase())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if an Entity can stack.
+     * 
+     * @param entity the Entity
+     * @param reason the SpawnReason, or null if the chunk is being loaded.
+     * @param worldChecked
+     * @return
+     */
+    private boolean isStackable(Entity entity, SpawnReason reason, boolean worldChecked) {
+
+        // Check world if not already checked.
+        if (!worldChecked && !isStackable(entity.getWorld())) {
+            return false;
+        }
+
+        // Ensure we have a living LivingEntity.
+        if (!(entity instanceof LivingEntity) || entity.isDead()) {
+            return false;
+        }
+
+        // No armor stands.
+        if (!Bukkit.getVersion().contains("1.7") && entity.getType() == EntityType.ARMOR_STAND) {
+            return false;
+        }
+
+        // Check if mob type is allowed to stack.
+        if (!getPlugin().getConfig().getBoolean("stack-mob-type." + entity.getType().toString())) {
+            return false;
+        }
+
+        // Check if spawn reason is allowed to cause stacking.
+        if (reason != null && !getPlugin().getConfig().getBoolean("stack-spawn-method." + reason)) {
+            return false;
+        }
+
+        // If we're using WorldGuard, check if the mob is in a region with stacking disabled.
+        if (getPlugin().usesWorldGuard()) {
+            RegionManager regionManager = getPlugin().getWorldGuard().getRegionManager(entity.getWorld());
+
+            for (ProtectedRegion region : regionManager.getApplicableRegions(entity.getLocation()).getRegions()) {
                 if (!getPlugin().regionAllowedToStack(region.getId())) {
-                    return;
+                    return false;
                 }
             }
-
         }
 
-        /*
-        If the mob is in a valid region, or WG isn't enabled, and we have mobs stacking, then...
-         */
-        if (getPlugin().isStacking()) {
+        return true;
 
-            /*
-            Check that this mob is allowed to stack and that it isn't dead for some reason.
-             */
-            if (getPlugin().getConfig().getBoolean("stack-mob-type." + spawnedCreature.getType().toString())
-                    && getPlugin().getConfig().getBoolean("stack-spawn-method." + spawnReason) && !entityIsArmorStand && !spawnedCreature.isDead()) {
-
-                /*
-                Set stack size to 1 and max stack to false;
-                 */
-                getPlugin().getStackUtils().setStackSize(spawnedCreature, 1);
-                getPlugin().getStackUtils().setMaxStack(spawnedCreature, false);
-
-                /*
-                Check for black listed worlds.
-                 */
-                List<String> worldBlackList = getPlugin().getConfig().getStringList("blacklist-world");
-
-                /*
-                Check if the mob is from a spawner, and add the tag so that when it dies we can have continuity for
-                nerf-spawner-mobs
-                 */
-                if (!spawnedCreature.hasMetadata("spawn-reason")) {
-
-                    spawnedCreature.setMetadata("spawn-reason", new FixedMetadataValue(getPlugin(), spawnReason));
-
-                }
-
-                /*
-                Make sure search time is positive and that the mob isn't in a blacklisted world, then try to stack it.
-                 */
-                if (getPlugin().getSearchTime() >= -20 && !worldBlackList.contains(spawnedCreature.getWorld().getName().toLowerCase())) {
-                    getPlugin().getStackUtils().attemptToStack(getPlugin().getSearchTime(), spawnedCreature, spawnReason);
-                }
-
-            }
-        }
     }
 
     public MobStacker getPlugin() {

--- a/src/config.yml
+++ b/src/config.yml
@@ -75,6 +75,22 @@ blacklist-world:
 mob-nerfing:
     - SPAWNER
 
+# Should previously stacked mobs be loaded back when chunks load? Note that spawn reason is lost, so options such as mob-nerfing will have no effect.
+load-existing-stacks:
+    enabled: true
+    mob-types:
+        - CHICKEN
+        - COW
+        - HORSE
+        - OCELOT
+        - PIG
+        - RABBIT
+        - SNOWMAN
+        - SHEEP
+        - SQUID
+        - VILLAGER
+        - WOLF
+
 # Mobs marked with true WILL attempt to stack. Mobs spawned by building (Golems and Wither) are a bit buggy, so it is suggested to leave them false.
 stack-mob-type:
     BAT: true


### PR DESCRIPTION
Bukkit's metadata is not persistent, unfortunately. This prevents issues with stacked mobs becoming a single named mob when chunks unload by parsing names when loading chunks.

Because spawn reason is lost, options such as `mob-nerfing` won't apply to reloaded stacks. On servers where players are allowed access to nametags which can mimic the MobStacker format this could allow players to name mobs, leave, and return to a freshly created stack. To combat this, there's an additional configuration section:

``` YAML
# Should previously stacked mobs be loaded back when chunks load? Note that spawn reason is lost, so options such as mob-nerfing will have no effect.
load-existing-stacks:
    enabled: true
    mob-types:
        - CHICKEN
        - COW
        - HORSE
        - OCELOT
        - PIG
        - RABBIT
        - SNOWMAN
        - SHEEP
        - SQUID
        - VILLAGER
        - WOLF
```

This way, users with farms won't be penalized for keeping stacked animals, but users with grinders still lose out by leaving without taking care of their mobs.
